### PR TITLE
fix(ci): initialize demo db via CLI to avoid Odoo 17 web API race condition

### DIFF
--- a/.github/setup-unit.sh
+++ b/.github/setup-unit.sh
@@ -69,37 +69,62 @@ done
 
 echo "✅ Odoo is ready"
 
-# Create the demo database via Odoo's web interface using curl
-echo "🗄️ Creating demo database..."
-
-# First, check if database already exists
-if curl -s -X POST -d "name=demo" http://localhost:8069/web/database/list | grep -q "demo"; then
-    echo "✅ Demo database already exists"
-else
-    # Create database using Odoo's database manager
-    # This simulates the database creation form submission
-    curl -s -X POST \
-        -d "master_pwd=admin" \
-        -d "name=demo" \
-        -d "login=test@demo.com" \
-        -d "password=admin" \
-        -d "phone=" \
-        -d "lang=en_US" \
-        -d "country_code=US" \
-        -d "demo=true" \
-        http://localhost:8069/web/database/create
-
-    # Wait a bit for database creation to complete
-    echo "⏳ Waiting for database creation to complete..."
-    sleep 30
-
-    # Verify database was created
-    if curl -s -X POST -d "name=demo" http://localhost:8069/web/database/list | grep -q "demo"; then
-        echo "✅ Demo database created successfully"
-    else
-        echo "⚠️ Database creation may still be in progress, tests will retry as needed"
+# Verify demo database is accessible and set up test user
+echo "⏳ Verifying demo database is accessible..."
+timeout=60
+elapsed=0
+while ! curl -s -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","method":"call","params":{"service":"common","method":"version","args":[]}}' \
+    http://localhost:8069/jsonrpc 2>/dev/null | grep -q "server_version"; do
+    if [ $elapsed -ge $timeout ]; then
+        echo "❌ Demo database not accessible within ${timeout} seconds"
+        exit 1
     fi
-fi
+    sleep 5
+    elapsed=$((elapsed + 5))
+    echo "⏳ Still waiting for demo database... (${elapsed}/${timeout}s)"
+done
+echo "✅ Demo database is accessible"
+
+# Create test user (test@demo.com) by updating the admin user's login
+echo "👤 Setting up test user test@demo.com..."
+python3 << 'PYTHON_EOF'
+import xmlrpc.client
+import sys
+
+url = 'http://localhost:8069'
+db = 'demo'
+
+try:
+    common = xmlrpc.client.ServerProxy(f'{url}/xmlrpc/2/common')
+    uid = common.authenticate(db, 'admin', 'admin', {})
+
+    if not uid:
+        print('❌ Cannot authenticate as admin to demo database')
+        sys.exit(1)
+
+    models = xmlrpc.client.ServerProxy(f'{url}/xmlrpc/2/object')
+
+    # Check if test@demo.com already exists
+    existing = models.execute_kw(db, uid, 'admin', 'res.users', 'search_count',
+                                  [[['login', '=', 'test@demo.com']]])
+    if existing > 0:
+        print('✅ User test@demo.com already exists')
+        sys.exit(0)
+
+    # Update admin user login to test@demo.com so tests can authenticate
+    models.execute_kw(db, uid, 'admin', 'res.users', 'write', [[uid], {
+        'login': 'test@demo.com',
+        'email': 'test@demo.com',
+        'name': 'Demo Admin',
+    }])
+    print('✅ Updated admin user login to test@demo.com')
+
+except Exception as e:
+    print(f'❌ Failed to set up test user: {e}')
+    sys.exit(1)
+PYTHON_EOF
 
 # Show status
 echo "📊 Container status:"

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   postgres:
     image: postgres:16
@@ -36,17 +35,15 @@ services:
       - ./config:/etc/odoo
     command: >
       bash -c "
-        # Wait a bit more for postgres to be fully ready
         sleep 5 &&
-        # Run Odoo with additional options for testing
-        odoo --database=postgres --db-filter=.* --load-language=en_US --without-demo=false --init=base
+        odoo -d demo --db-filter=.* --load-language=en_US --without-demo=all --init=base
       "
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8069/web/database/selector || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 30
-      start_period: 60s
+      start_period: 120s
 
 volumes:
   data:


### PR DESCRIPTION
## Summary

- Replace web API database creation (`/web/database/create`) with synchronous CLI initialization (`odoo -d demo --init=base`) to eliminate the `res.users` race condition that breaks Odoo 17 CI setup
- Use `--without-demo=all` to skip Odoo's built-in demo data, which is the source of the threading bug
- Increase Odoo healthcheck `start_period` from `60s` to `120s` to accommodate the longer synchronous init
- Remove the obsolete `version: '3.8'` top-level key from `docker-compose-ci.yml`
- Replace the curl-based database creation block in `setup-unit.sh` with a Python XML-RPC script that verifies the `demo` DB is reachable and renames the `admin` login to `test@demo.com` (which all tests expect)

## Why

The CLI `odoo -d demo --init=base` creates and fully initializes the PostgreSQL database before the HTTP server starts. When the Docker healthcheck passes, the database is guaranteed to be in a consistent state — no race condition, no partial `res.users` initialization.

## Test plan

- [ ] `rtk test ./gradlew test` passes locally (requires running `.github/setup-unit.sh` first)
- [ ] CI passes on this PR