### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/odoo/OdooAuthenticator.java
+++ b/src/main/java/io/kestra/plugin/odoo/OdooAuthenticator.java
@@ -61,7 +61,7 @@ public class OdooAuthenticator {
             throw new KestraRuntimeException("Unexpected authentication response from Odoo: " + result);
 
         } catch (Exception e) {
-            log.error("Authentication failed for user '{}' on database '{}': {}", username, database, e.getMessage(), e);
+            log.error("Authentication failed for user '[REDACTED]' on database '{}': {}", database, e.getMessage(), e);
             throw new KestraRuntimeException("Failed to authenticate with Odoo: " + e.getMessage(), e);
         }
     }

--- a/src/main/java/io/kestra/plugin/odoo/OdooClient.java
+++ b/src/main/java/io/kestra/plugin/odoo/OdooClient.java
@@ -73,7 +73,7 @@ public class OdooClient {
             throw new IllegalStateException("Not authenticated. Call authenticate() first.");
         }
 
-        logger.debug("Executing {}.{} with args: {}", model, method, args);
+        logger.debug("Executing {}.{} with {} argument(s)", model, method, args != null ? args.size() : 0);
 
         List<Object> params = Arrays.asList(database, uid, password, model, method, args);
         if (kwargs != null && !kwargs.isEmpty()) {

--- a/src/main/java/io/kestra/plugin/odoo/Query.java
+++ b/src/main/java/io/kestra/plugin/odoo/Query.java
@@ -147,6 +147,7 @@ public class Query extends Task implements RunnableTask<Query.Output> {
     )
     @NotNull
     @PluginProperty(secret = true, group = "main")
+    @ToString.Exclude
     private Property<String> username;
 
     @Schema(
@@ -155,6 +156,7 @@ public class Query extends Task implements RunnableTask<Query.Output> {
     )
     @NotNull
     @PluginProperty(secret = true, group = "main")
+    @ToString.Exclude
     private Property<String> password;
 
     @Schema(


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — Username logged in plaintext on authentication failure — `src/main/java/io/kestra/plugin/odoo/OdooAuthenticator.java:64` — Replaced the username with a `[REDACTED]` marker in the authentication-failure log statement so the secret-marked username is no longer persisted in plaintext to logs/log aggregators (CWE-532 / OWASP A09:2021).
- **MEDIUM** — `@ToString` on `Query` class exposes secret fields without `@ToString.Exclude` — `src/main/java/io/kestra/plugin/odoo/Query.java:25` — Added `@ToString.Exclude` to the `username` and `password` properties (both already `@PluginProperty(secret = true)`) so they are excluded from the generated `toString()` output.
- **LOW** — DEBUG-level logging of full XML-RPC method arguments including user-supplied values — `src/main/java/io/kestra/plugin/odoo/OdooClient.java:76` — Changed the debug log statement to report only the argument count instead of the raw argument list, avoiding incidental exposure of user-supplied/sensitive values at DEBUG level.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-odoo/issues/53
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
